### PR TITLE
Fix tile width error near southern width change lines, notably between 21°S and 22°S.

### DIFF
--- a/creator.py
+++ b/creator.py
@@ -53,8 +53,10 @@ TILE_HEIGHT = 0.125
 def get_tile_width(lat):
     """ Gets the width of a FG tile, in degrees. In FG, the width of a tile depends on the latitude """
     tile_table = [[0, 0.125], [22, 0.25], [62, 0.5], [76, 1], [83, 2], [86, 4], [89, 12]]
+    if lat < 0:
+        lat = abs(lat) - 1
     for i in range(len(tile_table)):
-        if tile_table[i][0] <= abs(lat) < tile_table[i + 1][0]:
+        if tile_table[i][0] <= lat < tile_table[i + 1][0]:
             return float(tile_table[i][1])
 
 


### PR DESCRIPTION
At negative latitudes, near tile width change lines, the tile width is miscalculated.
This leads to shifted tile coordinates and downloading the wrong tiles.

The most problematic locations are between -21 and -22 °S.
It can be seen easily in places like La Reunion or Mackay Airport,
Australia (tile id 5394737).

It must occur in the Antarctic as well, although no one cares.

This fix has been tested in the following places:
* La Réunion Island (tiles 3854644 and neighbors)
* Mackay, Australia (tiles 5394737 and neighbors)
* Sancti Spiritus, Cuba (tile 1645564 and neighbors, for non-regression at +22°)

Attached are two screenshots over Mackay Airport, with and without the fix. Without the fix, the aerial photo is of a nearby
patch of ocean.

![fgfs-20211218220315](https://user-images.githubusercontent.com/3317671/146657668-3dbd71a2-76fe-4597-bbd3-1f6793acd200.png)
![fgfs-20211218215042](https://user-images.githubusercontent.com/3317671/146657666-cf57dfee-c2c6-4958-9933-9bcb32f171cc.png)

Please note that I tested this fix only with the Arcgis source. 
